### PR TITLE
Added wildcard support to paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,13 @@
         </dependency>
 
         <dependency>
+            <groupId>no.ssb.dapla.catalog</groupId>
+            <artifactId>dapla-catalog-protobuf</artifactId>
+            <version>0.4</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>no.ssb.dapla.dlp.pseudo.func</groupId>
             <artifactId>dapla-dlp-pseudo-func</artifactId>
             <version>0.1.2</version>
@@ -147,6 +154,13 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.12</artifactId>
+            <version>2.4.5</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.12</artifactId>
             <version>2.4.5</version>
             <scope>provided</scope>
         </dependency>
@@ -405,6 +419,7 @@
                                     <include>no.ssb.dapla:dataset-uri</include>
                                     <include>no.ssb.dapla:metadata-distributor-protobuf</include>
                                     <include>no.ssb.dapla.data:*</include>
+                                    <include>no.ssb.dapla.catalog:*</include>
                                     <include>okhttp3:*</include>
                                     <include>com.auth0:*</include>
                                     <!-- Remove if google CredentialFactory is not used

--- a/src/main/java/no/ssb/dapla/service/CatalogClient.java
+++ b/src/main/java/no/ssb/dapla/service/CatalogClient.java
@@ -1,0 +1,108 @@
+package no.ssb.dapla.service;
+
+import no.ssb.dapla.catalog.protobuf.ListByPrefixRequest;
+import no.ssb.dapla.catalog.protobuf.ListByPrefixResponse;
+import no.ssb.dapla.spark.plugin.OAuth2Interceptor;
+import no.ssb.dapla.utils.ProtobufJsonUtils;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.apache.spark.SparkConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+public class CatalogClient {
+
+    public static final String CONFIG_CATALOG_URL = "spark.ssb.dapla.catalog.url";
+
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private OkHttpClient client;
+    private String baseURL;
+
+    public CatalogClient(final SparkConf conf) {
+        init(conf);
+    }
+
+    public void init(final SparkConf conf) {
+        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        OAuth2Interceptor.createOAuth2Interceptor(conf).ifPresent(builder::addInterceptor);
+        this.client = builder.build();
+        this.baseURL = conf.get(CONFIG_CATALOG_URL);
+        if (!this.baseURL.endsWith("/")) {
+            this.baseURL = this.baseURL + "/";
+        }
+    }
+
+    private String buildUrl(String format, Object... args) {
+        return this.baseURL + String.format(format, args);
+    }
+
+    public ListByPrefixResponse listByPrefix(ListByPrefixRequest listByPrefixRequest) {
+        Request request = new Request.Builder()
+                .url(buildUrl("rpc/CatalogService/listByPrefix"))
+                .post(RequestBody.create(ProtobufJsonUtils.toString(listByPrefixRequest), okhttp3.MediaType.get(MediaType.APPLICATION_JSON)))
+                .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            String json = getJson(response);
+            handleErrorCodes(response, json);
+            ListByPrefixResponse readLocationResponse = ProtobufJsonUtils.toPojo(json, ListByPrefixResponse.class);
+            return readLocationResponse;
+        } catch (IOException e) {
+            log.error("listByPrefix failed", e);
+            throw new CatalogServiceException(e);
+        }
+    }
+
+
+    private String getJson(Response response) throws IOException {
+        ResponseBody body = response.body();
+        if (body == null) return null;
+        return body.string();
+    }
+
+    private void handleErrorCodes(Response response, String body) {
+        if (response.code() == HttpURLConnection.HTTP_UNAUTHORIZED || response.code() == HttpURLConnection.HTTP_FORBIDDEN) {
+            throw new CatalogServiceException("Din bruker har ikke tilgang", body);
+        } else if (response.code() == HttpURLConnection.HTTP_NOT_FOUND) {
+            throw new NotFoundException("Fant ingen datasett", body);
+        } else if (response.code() < 200 || response.code() >= 400) {
+            throw new CatalogServiceException("En feil har oppstått: " + response.toString(), body);
+        }
+    }
+
+    public static class CatalogServiceException extends RuntimeException {
+        private final String body;
+
+        public CatalogServiceException(Throwable cause) {
+            super(cause);
+            this.body = null;
+        }
+
+        public CatalogServiceException(String message, String body) {
+            super(message);
+            this.body = body;
+        }
+
+        @Override
+        public String getMessage() {
+            if (body == null) {
+                return super.getMessage();
+            }
+            return super.getMessage() + "\n" + body;
+        }
+    }
+
+    public static class NotFoundException extends CatalogServiceException {
+        public NotFoundException(String message, String body) {
+            super(message, body);
+        }
+    }
+
+}

--- a/src/main/java/no/ssb/dapla/service/CatalogClient.java
+++ b/src/main/java/no/ssb/dapla/service/CatalogClient.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.concurrent.TimeUnit;
 
 public class CatalogClient {
 
@@ -37,7 +38,7 @@ public class CatalogClient {
     }
 
     public CatalogClient(final SparkConf conf, Span span) {
-        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        OkHttpClient.Builder builder = new OkHttpClient.Builder().callTimeout(10, TimeUnit.SECONDS);
 
         SparkConfStore store;
         if (conf != null) {

--- a/src/main/java/no/ssb/dapla/spark/plugin/CatalogRelation.java
+++ b/src/main/java/no/ssb/dapla/spark/plugin/CatalogRelation.java
@@ -55,8 +55,7 @@ public class CatalogRelation extends BaseRelation implements TableScan {
     }
 
     /**
-     * The equals should return true if it is known that the two relations will return the
-     * same data. Using the set of files guaranties this.
+     * Two relations will return the same data if the path is the same.
      */
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/no/ssb/dapla/spark/plugin/CatalogRelation.java
+++ b/src/main/java/no/ssb/dapla/spark/plugin/CatalogRelation.java
@@ -1,0 +1,78 @@
+package no.ssb.dapla.spark.plugin;
+
+import no.ssb.dapla.catalog.protobuf.DatasetId;
+import no.ssb.dapla.catalog.protobuf.ListByPrefixRequest;
+import no.ssb.dapla.catalog.protobuf.ListByPrefixResponse;
+import no.ssb.dapla.service.CatalogClient;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.sources.BaseRelation;
+import org.apache.spark.sql.sources.TableScan;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CatalogRelation extends BaseRelation implements TableScan {
+
+    private final SQLContext context;
+    private final String path;
+    private final Dataset<Row> dataFrame;
+
+    public class CatalogItem {
+        private final String path;
+
+        public CatalogItem(DatasetId datasetId) {
+            this.path = datasetId.getPath();
+        }
+
+        public String getPath() {
+            return path;
+        }
+    }
+
+    public CatalogRelation(SQLContext context, String path) {
+        this.context = context;
+        this.path = path;
+        CatalogClient catalogClient = new CatalogClient(context.sparkContext().getConf());
+        ListByPrefixResponse response = catalogClient.listByPrefix(ListByPrefixRequest.newBuilder().setPrefix(path).build());
+
+        List<CatalogItem> catalogItems = response.getEntriesList().stream().map(CatalogItem::new).collect(Collectors.toList());
+        this.dataFrame = sqlContext().createDataFrame(catalogItems, CatalogItem.class);
+    }
+
+    @Override
+    public RDD<Row> buildScan() {
+        return dataFrame.rdd();
+    }
+
+    @Override
+    public StructType schema() {
+        return dataFrame.schema();
+    }
+
+    /**
+     * The equals should return true if it is known that the two relations will return the
+     * same data. Using the set of files guaranties this.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CatalogRelation that = (CatalogRelation) o;
+        return path.equals(that.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return path.hashCode();
+    }
+
+    @Override
+    public SQLContext sqlContext() {
+        return this.context;
+    }
+
+}

--- a/src/main/java/no/ssb/dapla/spark/plugin/GsimDatasource.java
+++ b/src/main/java/no/ssb/dapla/spark/plugin/GsimDatasource.java
@@ -53,7 +53,7 @@ public class GsimDatasource implements RelationProvider, CreatableRelationProvid
     public BaseRelation createRelation(final SQLContext sqlContext, Map<String, String> parameters) {
         Span span = getSpan(sqlContext, "spark-read");
         try {
-            log.info("CreateRelation via read {}", parameters);
+            span.log("CreateRelation via read ");
             SparkOptions options = new SparkOptions(parameters);
             final String path = options.getPath();
             if (path.endsWith("*")) {

--- a/src/main/java/no/ssb/dapla/spark/plugin/GsimDatasource.java
+++ b/src/main/java/no/ssb/dapla/spark/plugin/GsimDatasource.java
@@ -49,6 +49,15 @@ public class GsimDatasource implements RelationProvider, CreatableRelationProvid
     public BaseRelation createRelation(final SQLContext sqlContext, Map<String, String> parameters) {
         log.info("CreateRelation via read {}", parameters);
         SparkOptions options = new SparkOptions(parameters);
+        final String path = options.getPath();
+        if (path.endsWith("*")) {
+            return new CatalogRelation(sqlContext, path.substring(0, path.indexOf("*")));
+        } else {
+            return createRelation(sqlContext, options);
+        }
+    }
+
+    private BaseRelation createRelation(final SQLContext sqlContext, SparkOptions options) {
         final String localPath = options.getPath();
         System.out.println("Leser datasett fra: " + localPath);
 

--- a/src/test/java/no/ssb/dapla/service/CatalogClientTest.java
+++ b/src/test/java/no/ssb/dapla/service/CatalogClientTest.java
@@ -1,5 +1,7 @@
 package no.ssb.dapla.service;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
 import no.ssb.dapla.catalog.protobuf.ListByPrefixRequest;
 import no.ssb.dapla.catalog.protobuf.ListByPrefixResponse;
 import okhttp3.HttpUrl;
@@ -10,6 +12,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 
 import static no.ssb.dapla.service.CatalogClient.*;
 import static no.ssb.dapla.spark.plugin.DaplaSparkConfig.*;
@@ -29,8 +34,8 @@ public class CatalogClientTest {
         this.sparkConf.set(CONFIG_ROUTER_OAUTH_TOKEN_URL, "http://localhost"); // not used
         this.sparkConf.set(CONFIG_ROUTER_OAUTH_CLIENT_ID, "na");
         this.sparkConf.set(CONFIG_ROUTER_OAUTH_CLIENT_SECRET, "na");
-        this.sparkConf.set(CONFIG_ROUTER_OAUTH_TOKEN_IGNORE_EXPIRY, "true");
-        this.sparkConf.set("spark.ssb.access", "na");
+        this.sparkConf.set("spark.ssb.access", JWT.create().withClaim("preferred_username", "johndoe")
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS))).sign(Algorithm.HMAC256("secret")));
     }
 
     @Test

--- a/src/test/java/no/ssb/dapla/service/CatalogClientTest.java
+++ b/src/test/java/no/ssb/dapla/service/CatalogClientTest.java
@@ -1,0 +1,56 @@
+package no.ssb.dapla.service;
+
+import no.ssb.dapla.catalog.protobuf.ListByPrefixRequest;
+import no.ssb.dapla.catalog.protobuf.ListByPrefixResponse;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.spark.SparkConf;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static no.ssb.dapla.service.CatalogClient.*;
+import static no.ssb.dapla.spark.plugin.DaplaSparkConfig.*;
+import static org.assertj.core.api.Assertions.*;
+
+public class CatalogClientTest {
+
+    private SparkConf sparkConf = new SparkConf();
+    private MockWebServer server;
+
+    @Before
+    public void setUp() throws IOException {
+        this.server = new MockWebServer();
+        this.server.start();
+        HttpUrl baseUrl = server.url("/catalog/");
+        this.sparkConf.set(CONFIG_CATALOG_URL, baseUrl.toString());
+        this.sparkConf.set(CONFIG_ROUTER_OAUTH_TOKEN_URL, "http://localhost"); // not used
+        this.sparkConf.set(CONFIG_ROUTER_OAUTH_CLIENT_ID, "na");
+        this.sparkConf.set(CONFIG_ROUTER_OAUTH_CLIENT_SECRET, "na");
+        this.sparkConf.set(CONFIG_ROUTER_OAUTH_TOKEN_IGNORE_EXPIRY, "true");
+        this.sparkConf.set("spark.ssb.access", "na");
+    }
+
+    @Test
+    public void testListByPrefix() {
+        server.enqueue(new MockResponse()
+                .setBody("{\n" +
+                        "  \"entries\": [{\n" +
+                        "    \"path\": \"/skatt/person/test1\",\n" +
+                        "    \"timestamp\": \"1585256968006\"\n" +
+                        "  }, {\n" +
+                        "    \"path\": \"/skatt/person/test2\",\n" +
+                        "    \"timestamp\": \"1582719098762\"\n" +
+                        "  }]\n" +
+                        "}\n")
+                .setResponseCode(200));
+        CatalogClient dataAccessClient = new CatalogClient(this.sparkConf);
+        ListByPrefixResponse response = dataAccessClient.listByPrefix(ListByPrefixRequest.newBuilder()
+                .setPrefix("/skatt/person/")
+                .build());
+        assertThat(response.getEntriesCount()).isEqualTo(2);
+    }
+
+}

--- a/src/test/java/no/ssb/dapla/spark/plugin/CatalogRelationTest.java
+++ b/src/test/java/no/ssb/dapla/spark/plugin/CatalogRelationTest.java
@@ -1,8 +1,7 @@
 package no.ssb.dapla.spark.plugin;
 
-import no.ssb.dapla.catalog.protobuf.ListByPrefixRequest;
-import no.ssb.dapla.catalog.protobuf.ListByPrefixResponse;
-import no.ssb.dapla.service.CatalogClient;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -15,6 +14,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 
 import static no.ssb.dapla.service.CatalogClient.*;
 import static no.ssb.dapla.spark.plugin.DaplaSparkConfig.*;
@@ -42,7 +44,9 @@ public class CatalogRelationTest {
                 .config(CONFIG_ROUTER_OAUTH_CLIENT_ID, "na")
                 .config(CONFIG_ROUTER_OAUTH_CLIENT_SECRET, "na")
                 .config(CONFIG_ROUTER_OAUTH_TOKEN_IGNORE_EXPIRY, "true")
-                .config("spark.ssb.access", "na")
+                .config("spark.ssb.access", JWT.create().withClaim("preferred_username", "john")
+                        .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                        .sign(Algorithm.HMAC256("secret")))
                 .getOrCreate();
 
         this.sparkContext = session.sparkContext();

--- a/src/test/java/no/ssb/dapla/spark/plugin/CatalogRelationTest.java
+++ b/src/test/java/no/ssb/dapla/spark/plugin/CatalogRelationTest.java
@@ -1,0 +1,75 @@
+package no.ssb.dapla.spark.plugin;
+
+import no.ssb.dapla.catalog.protobuf.ListByPrefixRequest;
+import no.ssb.dapla.catalog.protobuf.ListByPrefixResponse;
+import no.ssb.dapla.service.CatalogClient;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SparkSession;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static no.ssb.dapla.service.CatalogClient.*;
+import static no.ssb.dapla.spark.plugin.DaplaSparkConfig.*;
+import static org.assertj.core.api.Assertions.*;
+
+public class CatalogRelationTest {
+
+    private SQLContext sqlContext;
+    private SparkContext sparkContext;
+    private MockWebServer catalogMockServer;
+
+    @Before
+    public void setUp() throws IOException {
+        this.catalogMockServer = new MockWebServer();
+        this.catalogMockServer.start();
+        HttpUrl baseUrl = catalogMockServer.url("/catalog/");
+
+        // Read the unit dataset json example.
+        SparkSession session = SparkSession.builder()
+                .appName(GsimDatasourceLocalFSTest.class.getSimpleName())
+                .master("local")
+                .config("spark.ui.enabled", false)
+                .config(CONFIG_CATALOG_URL, baseUrl.toString())
+                .config(CONFIG_ROUTER_OAUTH_TOKEN_URL, "http://localhost") // not used
+                .config(CONFIG_ROUTER_OAUTH_CLIENT_ID, "na")
+                .config(CONFIG_ROUTER_OAUTH_CLIENT_SECRET, "na")
+                .config(CONFIG_ROUTER_OAUTH_TOKEN_IGNORE_EXPIRY, "true")
+                .config("spark.ssb.access", "na")
+                .getOrCreate();
+
+        this.sparkContext = session.sparkContext();
+        this.sqlContext = session.sqlContext();
+    }
+
+    @Test
+    public void testListByPrefix() {
+        catalogMockServer.enqueue(new MockResponse()
+                .setBody("{\n" +
+                        "  \"entries\": [{\n" +
+                        "    \"path\": \"/skatt/person/test1\",\n" +
+                        "    \"timestamp\": \"1585256968006\"\n" +
+                        "  }, {\n" +
+                        "    \"path\": \"/skatt/person/test2\",\n" +
+                        "    \"timestamp\": \"1582719098762\"\n" +
+                        "  }]\n" +
+                        "}\n")
+                .setResponseCode(200));
+
+        Dataset<Row> dataset = sqlContext.read()
+                .format("gsim")
+                .load("/skatt/person/*");
+
+        assertThat(dataset).isNotNull();
+        dataset.printSchema();
+        dataset.show();
+        assertThat(dataset.count()).isEqualTo(2);
+    }
+}

--- a/src/test/java/no/ssb/dapla/spark/plugin/GsimDatasourceGCSTest.java
+++ b/src/test/java/no/ssb/dapla/spark/plugin/GsimDatasourceGCSTest.java
@@ -174,8 +174,6 @@ public class GsimDatasourceGCSTest {
         Dataset<Row> dataset = sqlContext.read()
                 .load(parquetFile.toString());
 
-        dataset.printSchema();
-        //dataset.show();
         assertThat(dataset).isNotNull();
         assertThat(dataset.isEmpty()).isFalse();
     }

--- a/src/test/java/no/ssb/dapla/spark/plugin/GsimDatasourceGCSTest.java
+++ b/src/test/java/no/ssb/dapla/spark/plugin/GsimDatasourceGCSTest.java
@@ -174,6 +174,8 @@ public class GsimDatasourceGCSTest {
         Dataset<Row> dataset = sqlContext.read()
                 .load(parquetFile.toString());
 
+        dataset.printSchema();
+        //dataset.show();
         assertThat(dataset).isNotNull();
         assertThat(dataset.isEmpty()).isFalse();
     }


### PR DESCRIPTION
The following PR adds the ability to browse the namespace paths that can be read via the dapla-spark-plugin. Example:

```scala
val datasett = spark.read.format("gsim").load("/skatt/person/*")
z.show(datasett)
```
This could produce the following output
```
+-------------------+
|               path|
+-------------------+
|/skatt/person/test1|
|/skatt/person/test2|
+-------------------+
```