### PR TITLE
Custom pyspark extension to update access tokens on demand.

### DIFF
--- a/docker/jupyter/custom_auth/authenticator.py
+++ b/docker/jupyter/custom_auth/authenticator.py
@@ -6,6 +6,7 @@ from oauthenticator.generic import GenericOAuthenticator
 
 # Pre-Spawn custom class to retrieve user access token
 class EnvGenericOAuthenticator(GenericOAuthenticator):
+
     async def pre_spawn_start(self, user, spawner):
 
         self.log.info('Calling pre_spawn_start for: ' + user.name)
@@ -17,9 +18,7 @@ class EnvGenericOAuthenticator(GenericOAuthenticator):
             return
 
         # update env var to pass to notebooks
-        self.log.info('Passing credentials to notebook for: ' + user.name)
-        spawner.environment['SSB_ACCESS'] = auth_state['access_token']
-        spawner.environment['SSB_REFRESH'] = auth_state['refresh_token']
+        self.log.info('Starting notebook for: ' + user.name)
 
     # Refresh user access and refresh tokens (called periodically)
     async def refresh_user(self, user, handler, force=True):
@@ -42,10 +41,6 @@ class EnvGenericOAuthenticator(GenericOAuthenticator):
         elif diff_refresh<0:
             # Refresh token not valid, need to completely reauthenticate
             self.log.info('Refresh token not valid, need to completely reauthenticate for: ' +  user.name)
-            # Fron https://discourse.jupyter.org/t/how-to-force-re-login-for-users/1998/11
-            await handler.stop_single_user(user, user.spawner.name)
-            handler.clear_cookie("jupyterhub-hub-login")
-            handler.clear_cookie("jupyterhub-session-id")
             refresh_user_return = False
         else:
             # We need to refresh access token (which will also refresh the refresh token)

--- a/docker/jupyter/custom_auth/authextension.py
+++ b/docker/jupyter/custom_auth/authextension.py
@@ -1,0 +1,31 @@
+from tornado import gen, web
+from jupyterhub.handlers import BaseHandler
+
+"""
+A custom request handler for JupyterHub. This handler returns user and auth state info
+"""
+class AuthHandler(BaseHandler):
+
+    @web.authenticated
+    async def get(self):
+        user = await self.get_current_user()
+        if user is None:
+            self.log.info('User is none')
+            # whoami can be accessed via oauth token
+            user = self.get_current_user_oauth_token()
+        if user is None:
+            raise web.HTTPError(403)
+
+        self.log.info('User is ' + user.name)
+        auth_state = await user.get_auth_state()
+        if not auth_state:
+            # user has no auth state
+            self.log.error('User has no auth state')
+            return
+
+        self.write({
+            "username" : user.name,
+            "access_token" : auth_state['access_token'],
+            "refresh_token" : auth_state['refresh_token'],
+        })
+

--- a/docker/jupyter/custom_auth/sparkextension.py
+++ b/docker/jupyter/custom_auth/sparkextension.py
@@ -1,0 +1,50 @@
+import os
+import requests
+import jwt
+import time
+from pyspark.sql import DataFrameReader
+from pyspark.sql import SparkSession
+from pyspark import SparkContext
+
+"""
+This extension will replace `spark.read.format("gsim").load("/ns")` with
+ `spark.read.namespace("/ns")`, and at the same time add access token reload the spark context if necessary.
+"""
+def load_extensions():
+    DataFrameReader.namespace = namespace_read
+
+def namespace_read(self, ns):
+    return get_session().read.format("gsim").load(ns)
+
+def get_session():
+    session = SparkSession._instantiatedSession
+    if should_reload_token(session.sparkContext.getConf()):
+        # Load new spark session
+        print("Fetch new access token")
+        update_tokens(session._jsparkSession.sessionState().conf())
+    else:
+        print("Reusing access token")
+    return session
+
+def should_reload_token(conf):
+    spark_token = conf.get("spark.ssb.access")
+    if spark_token is None:
+        print("No spark token")
+        return True
+
+    access_token = jwt.decode(spark_token, verify=False)
+    diff_access = access_token['exp'] - time.time()
+    # Should fetch new token from server if the access token expires in 10 secs
+    if diff_access>10:
+        return False
+    else:
+        return True
+
+def update_tokens(conf):
+    response = requests.get("http://127.0.0.1:8081/hub/custom-api/user",
+                            headers={
+                                'Authorization': 'token %s' % os.environ["JUPYTERHUB_API_TOKEN"]
+                            }).json()
+    #return conf.setConfString("spark.ssb.access", response['access_token'])
+    SparkContext._active_spark_context._conf.set("spark.ssb.access", response['access_token'])
+

--- a/docker/jupyter/custom_auth/sparkextension.py
+++ b/docker/jupyter/custom_auth/sparkextension.py
@@ -21,7 +21,7 @@ def get_session():
     if should_reload_token(session.sparkContext.getConf()):
         # Load new spark session
         print("Fetch new access token")
-        update_tokens(session._jsparkSession.sessionState().conf())
+        update_tokens()
     else:
         print("Reusing access token")
     return session
@@ -40,11 +40,10 @@ def should_reload_token(conf):
     else:
         return True
 
-def update_tokens(conf):
+def update_tokens():
     response = requests.get("http://127.0.0.1:8081/hub/custom-api/user",
                             headers={
                                 'Authorization': 'token %s' % os.environ["JUPYTERHUB_API_TOKEN"]
                             }).json()
-    #return conf.setConfString("spark.ssb.access", response['access_token'])
     SparkContext._active_spark_context._conf.set("spark.ssb.access", response['access_token'])
 

--- a/docker/jupyter/custom_auth/sparkextension.py
+++ b/docker/jupyter/custom_auth/sparkextension.py
@@ -20,17 +20,14 @@ def namespace_read(self, ns):
 def get_session():
     session = SparkSession._instantiatedSession
     if should_reload_token(session.sparkContext.getConf()):
-        # Load new spark session
-        print("Fetch new access token")
+        # Fetch new access token
         update_tokens()
-    else:
-        print("Reusing access token")
     return session
 
 def should_reload_token(conf):
     spark_token = conf.get("spark.ssb.access")
     if spark_token is None:
-        print("No spark token")
+        # First time fetching the token
         return True
 
     access_token = jwt.decode(spark_token, verify=False)

--- a/docker/jupyter/kernels/pyspark-cluster/init.py
+++ b/docker/jupyter/kernels/pyspark-cluster/init.py
@@ -1,7 +1,14 @@
+import atexit
 import os
 from pyspark.sql import SparkSession
+from custom_auth.sparkextension import load_extensions
 
-spark = SparkSession.builder.appName(os.environ["JUPYTERHUB_CLIENT_ID"]) \
-    .config("spark.ssb.access", os.environ["SSB_ACCESS"]) \
-    .config("spark.ssb.refresh", os.environ["SSB_REFRESH"]) \
-    .getOrCreate()
+spark = SparkSession.builder.appName(os.environ["JUPYTERHUB_CLIENT_ID"]).getOrCreate()
+
+# This is similar to /pyspark/shell.py
+sc = spark.sparkContext
+sql = spark.sql
+atexit.register(lambda: sc.stop())
+
+# This registers the custom pyspark extensions
+load_extensions()

--- a/docker/jupyter/kernels/pyspark-local/init.py
+++ b/docker/jupyter/kernels/pyspark-local/init.py
@@ -1,12 +1,20 @@
+import atexit
 import os
 from pyspark.sql import SparkSession
+from custom_auth.sparkextension import load_extensions
 
 spark = SparkSession.builder.appName(os.environ["JUPYTERHUB_CLIENT_ID"]) \
     .config("spark.submit.deployMode", "client") \
-    .config("spark.ssb.access", os.environ["SSB_ACCESS"]) \
-    .config("spark.ssb.refresh", os.environ["SSB_REFRESH"]) \
     .config("spark.ssb.dapla.oauth.tokenUrl", os.environ["OAUTH2_TOKEN_URL"]) \
     .config("spark.ssb.dapla.metadata.publisher.url", os.environ["METADATA_PUBLISHER_URL"]) \
     .config("spark.ssb.dapla.data.access.url", os.environ["DATA_ACCESS_URL"]) \
     .config("spark.ssb.dapla.catalog.url", os.environ["CATALOG_URL"]) \
     .getOrCreate()
+
+# This is similar to /pyspark/shell.py
+sc = spark.sparkContext
+sql = spark.sql
+atexit.register(lambda: sc.stop())
+
+# This registers the custom pyspark extensions
+load_extensions()


### PR DESCRIPTION
This PR removes the environment variables that holds the user's access tokens. Instead, the pyspark session is added with an extension to update access tokens on demand.

So, instead of writing ```spark.read.format("gsim").load("/myNamespace") ``` use ```spark.read.namespace("/myNamespace")```

The overloaded namespace method will ensure that the spark config value "spark.ssb.access" is always valid.

A custom handler must be added to jupyterhub using:
```python
from custom_auth.authextension import AuthHandler
c.JupyterHub.extra_handlers = [
    (r"/custom-api/user", AuthHandler)
]
```